### PR TITLE
Make a executable jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Pushy Console is currently distributed as a source-only project. To get Pushy Co
 
 ```sh
 # Note: compilation only needs to happen once (or when the source code changes)
-mvn clean compile
+mvn clean package
 
+java -jar target/pushy-console-${version}.jar
+# or execute through maven
 mvn exec:java -Dexec.mainClass="com.turo.pushy.console.PushyConsoleApplication"
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,45 @@
                     </links>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${maven.dependencies.dir}</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.turo.pushy.console.PushyConsoleApplication</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>${maven.dependencies.dir}/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <properties>
+        <maven.dependencies.dir>lib</maven.dependencies.dir>
+    </properties>
+
 </project>


### PR DESCRIPTION
This PR makes a executable jar by copying dependencies into one directory and setting appropriate MANIFEST file for the jar.

It feels to me executing a jar is more straightforward than running maven exec goals.

P.S. maven shade plugin could be used to generate an uber-jar but due to BouncyCastle dependency it fails with "Invalid signature..." errors.