### PR TITLE
Package Pushy Console as an executable uber-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,42 +95,44 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/${maven.dependencies.dir}</outputDirectory>
-                            <includeScope>runtime</includeScope>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>
                             <mainClass>com.turo.pushy.console.PushyConsoleApplication</mainClass>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>${maven.dependencies.dir}/</classpathPrefix>
                         </manifest>
                     </archive>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
-    <properties>
-        <maven.dependencies.dir>lib</maven.dependencies.dir>
-    </properties>
-
 </project>


### PR DESCRIPTION
This builds on @bazi's work in #15 and builds a full-blown uber-jar. I used the advice from http://zhentao-li.blogspot.com/2012/06/maven-shade-plugin-invalid-signature.html to resolve some complaints about invalid signatures.

This closes #16.