### PR TITLE
#19 - Fix issue with I18N

### DIFF
--- a/src/main/resources/com/turo/pushy/console/pushy-console.properties
+++ b/src/main/resources/com/turo/pushy/console/pushy-console.properties
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2018 Turo Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+alert.bad-certificate.title=Invalid certificate
+alert.bad-certificate.header=The certificate you chose doesn't appear to be a valid APNs certificate.
+alert.bad-certificate.content-text=The chosen certificate doesn't identify an APNs topic as a UID in its subject.
+
+alert.notification-failed.title=Failed to send push notification
+alert.notification-failed.header=An exception was thrown while sending a push notification.
+
+certificate-chooser.filter.pkcs8_and_pkcs12=PKCS#8 and PKCS#12 files
+certificate-chooser.filter.pkcs12=PKCS#12 files (certificates)
+certificate-chooser.filter.pkcs8=PKCS#8 files (signing keys)
+certificate-chooser.filter.all=All files
+
+certificate-password-dialog.title=Enter password
+certificate-password-dialog.header=Please enter the password for {0}.
+certificate-password-dialog.prompt=Password
+
+delivery-priority.immediate=Immediate
+delivery-priority.conserve-power=Conserve power
+
+notification-result.placeholder=No notifications sent
+notification-result.details.accepted=n/a
+notification-result.details.expiration={0} ({1,date,yyyy-MM-dd} {1,time,HH:mm:ss})
+notification-result.status.accepted=Accepted
+notification-result.status.rejected=Rejected
+
+password-dialog.incorrect-password=The password you entered is incorrect. Please try again.
+
+pushy-console.title=Pushy Console
+
+fxml.apns-server.label=APNs server
+fxml.port.label=Port
+fxml.credentials.label=Credentials
+fxml.browse.label=Browse…
+fxml.key-id.label=Key ID
+fxml.team-id.label=Team ID
+fxml.topic.label=Topic
+fxml.token.label=Device token
+fxml.collapse-id.label=Collapse ID
+fxml.priority.label=Priority
+fxml.recent-payloads.label=Recent payloads
+fxml.payload.label=Payload
+fxml.send.label=Send notification
+fxml.notification.label=Notification
+fxml.response.label=Response
+fxml.status.label=Status
+fxml.details.label=Details
+fxml.apns-id.label=APNs ID
+


### PR DESCRIPTION
Java tries to load the properties with the "language extension" which
matches the current system: "If still no result bundle is found, the base
name alone is looked up."
See https://docs.oracle.com/javase/7/docs/api/java/util/ResourceBundle.html