### PR TITLE
#19 Copy _en.properties as default language

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,36 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>copy-default-language</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <!--
+                        Because the application crashes if no default language can be found,
+                        copy the english messages file as default messages.
+                        -->
+                        <configuration>
+                            <target>
+                                <copy todir="target/classes/com/turo/pushy/console/">
+                                    <fileset dir="src/main/resources/com/turo/pushy/console/">
+                                        <include name="**/*_en.properties"/>
+                                    </fileset>
+                                    <mapper type="glob"
+                                            from="pushy-console_en.properties"
+                                            to="pushy-console.properties"/>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>8</source>


### PR DESCRIPTION
The symlink solution might raise issues. It seems better to copy the
pushy-console_en.properties file to pushy-console.properties during
the process-resources phase of maven.